### PR TITLE
add plan to return type; consolidate plan info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+### Background
+
+[Describe the background for this PR here.
+Edit this description and all other fields in square brackets. Check the box when the item is fully resolved, check and add "N/A" if not applicable.]
+
+### What's new
+
+- [ ] [New feature description]
+
+### Related work
+
+- [ ] [link] needs this PR
+
+### TODOs / Nice-To-Haves
+
+- [ ] [Add system tests for new feature.]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,32 +22,35 @@ if (NOT GRPC_CPP_PLUGIN)
 endif()
 
  # create a new library pointing to the api definition
- add_library(protodefs SHARED ${CMAKE_CURRENT_SOURCE_DIR}/proto/planning/api.proto)
- # link against protobuf and gRPC
- target_link_libraries(protodefs
-     PUBLIC
-     protobuf::libprotobuf
-     grpc++
-     grpc++_reflection
- )
- # add to include directories
- target_include_directories(protodefs PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
- # 1.) generate protobuf serializations
- protobuf_generate(
-     TARGET protodefs
-     LANGUAGE cpp
-     OUT_VAR PROTO_FILES
- )
- # 2.) generate gRPC files using serializations from the previous step
- protobuf_generate(
-     TARGET protodefs
-     LANGUAGE grpc
-     OUT_VAR PROTO_FILES
-     GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
-     PLUGIN "protoc-gen-grpc=${GRPC_CPP_PLUGIN}"
- )
- # set as generated
- set_source_files_properties(${PROTO_FILES} PROPERTIES GENERATED TRUE)
- # add to include directories
- target_include_directories(protodefs PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+add_library(protodefs SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/proto/planning/api.proto
+    ${CMAKE_CURRENT_SOURCE_DIR}/proto/planning/types.proto
+)
+# link against protobuf and gRPC
+target_link_libraries(protodefs
+    PUBLIC
+    protobuf::libprotobuf
+    grpc++
+    grpc++_reflection
+)
+# add to include directories
+target_include_directories(protodefs PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+# 1.) generate protobuf serializations
+protobuf_generate(
+    TARGET protodefs
+    LANGUAGE cpp
+    OUT_VAR PROTO_FILES
+)
+# 2.) generate gRPC files using serializations from the previous step
+protobuf_generate(
+    TARGET protodefs
+    LANGUAGE grpc
+    OUT_VAR PROTO_FILES
+    GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
+    PLUGIN "protoc-gen-grpc=${GRPC_CPP_PLUGIN}"
+)
+# set as generated
+set_source_files_properties(${PROTO_FILES} PROPERTIES GENERATED TRUE)
+# add to include directories
+target_include_directories(protodefs PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/proto/planning/api.proto
+++ b/proto/planning/api.proto
@@ -1,131 +1,16 @@
 syntax = "proto3";
 
-
 package proto;
-// Joint configuration for a single robot
-message Conf {
-  repeated double data = 1;
-}
 
-// "System configuration", legacy type mapping individual robots
-// to respective independent configurations
-message SystemConf {
-  map<string, Conf> data = 1;
-}
-
-// all data required to uniquely define a planning problem
-// (alongside the problem URDF)
-message ProblemDef {
-  string name = 1;
-  SystemConf goal = 2;
-  SystemConf start = 3;
-  double orientation_tol = 4;
-  bool use_columnar_constraint = 5;
-  bool use_height_constraint = 6;
-  double discretization = 7;
-}
-// Constrains the position of a point Q, rigidly attached to a frame B, to be
-// within a bounding box measured and expressed in frame A.
-// Reference: https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_position_constraint.html
-message PositionConstraint {
-  string frame_A = 1;
-  string frame_B = 2;
-  repeated double p_AQ_lower = 3;
-  repeated double p_AQ_upper = 4;
-  repeated double p_BQ = 5;
-}
-// Constrains that the angle between a vector a and another vector b is
-// between [θ_lower, θ_upper].
-// Reference: https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_angle_between_vectors_constraint.html
-message AngleBetweenVectorsConstraint {
-  string frame_A = 1;
-  string frame_B = 2;
-  repeated double a_A = 3;
-  repeated double b_B = 4;
-  double angle_lower = 5;
-  double angle_upper = 6;
-}
-// Collection of all constraints enforced on the given plan
-message Constraints {
-  repeated PositionConstraint pos_constraints = 1;
-  repeated AngleBetweenVectorsConstraint angle_constraints = 2;
-  // TODO(@davebambrick): Add collision checking
-}
-
-// Joint limits for each joint in the system
-message JointLimits {
-  repeated double lower = 1;
-  repeated double upper = 2;
-}
-
-// placeholder message type for "new" params (to be
-// used by GCS)
-message Params {
-  string system_name = 1;
-  string model_directive = 2;
-  string robot_name = 3;
-  string link_name = 4;
-  repeated double link_axis = 5;
-  repeated double world_axis = 6;
-  JointLimits joint_position_limits = 7; // need convert to std::pair<VectorX<double>, VectorX<double>>
-
-  // planning params
-  double max_solve_time = 8;
-  double position_tolerance = 9;
-  double orientation_tolerance = 10;
-  double collision_buffer_meters = 11;
-  bool check_plan_validity = 12;
-  double collision_cost_scale = 13;
-  double orientation_cost_scale = 14;
-  double stretch_factor = 15;
-  double dense_delta = 16;
-  bool dense_roadmap = 17;
-  double heuristic_scaling = 18;
-
-  // recall from database
-  bool recall = 19;
-  double recall_time_cap_seconds = 20;
-  bool collision_check_on_recall = 21;
-}
-
-// system polynomial; a map of individual
-// polynomials to their respective target robots
-message SysPoly {
-  map<string, Poly> data = 1;
-}
-
-// individual piecewise polynomial trajectory, uniquely defined by
-//   1) an array of "breaks", or points in time representing
-//      the intervals for constituent polynomials.
-//   2) an array of m-by-n matrices of coeffecient vectors, where
-//      a single constituent matrix uniquely defines a given
-//      polynomial. each matrix contains the coefficients of the
-//      underlying additive monomials.
-// note: the coeffecients are stored in this message type
-// as a vector of vectors, so care must be taken to properly
-// unpack this data into the appropriate structure
-message Poly {
-  repeated double breaks = 1;
-  uint32 rows = 2;
-  uint32 cols = 3;
-  // vector of monomial coefficients
-  repeated Coeffs coeffs = 4;
-}
-
-// a vector of coefficients for a single monomial
-message Coeffs {
-  repeated double data = 1;
-}
-
-// request sent by a client to start a given plan
+/** Request containing all information necessary to uniquely define a planning
+ * problem in a format accepted by the planner. */
 message StartPlanRequest {
   string id = 1;
   ProblemDef def = 2;
-  Params params = 3;
-  string legacy_params = 4; // TODO(@davebambrick): deprecate
-  Constraints constraints = 5;
+  string legacy_params = 4;  // TODO(@davebambrick): deprecate
 }
-
+/** Response which contains the result of attempting to start computation of a
+ * solution for the corresponding StartPlanRequest. */
 message StartPlanResponse {
   string id = 1;
   bool success = 2;
@@ -134,34 +19,44 @@ message StartPlanResponse {
   string msg = 3;
 }
 
-// retrieve type dictating the behavior when retrieving a given plan
+/** Enum which controls plan retrieval behavior for a given RetrievePlanRequest.
+ * Retrieval behavior is as follows:
+ *   - UNSPECIFIED. Default value
+ *   - BLOCKING. Wait indefinitely for the computation of the plan to complete.
+ *   - IF_READY. Only return if computation is completed at the time of reciept
+ *     of the request. Equivalent to a timeout of length zero.
+ *   - WITH_TIMEOUT. Wait for a maximum interval of timeout_ms for computation
+ *     to complete before returning failure.
+ */
 enum RetrieveType {
   UNSPECIFIED = 0;
-  // block until the plan is ready
   BLOCKING = 1;
-  // only retrieve if ready
   IF_READY = 2;
-  // wait for a give timeout
   WITH_TIMEOUT = 3;
 }
-// request sent by a client to retrieve a plan with the given ID
+/** Request to retrieve a plan with a unique ID, in the manner dictated by the
+ * given retrieval type. */
 message RetrievePlanRequest {
   string id = 1;
   RetrieveType retrieve_type = 2;
   uint32 timeout_ms = 3;
 }
 
+/** Response which contains the result of retrieving the plan with the given ID.
+ */
 message RetrievePlanResponse {
   string id = 1;
   bool success = 2;
-  SysPoly plan = 3;
   // msg used to convey extra information to client; usually
   // for explaining cause of error
-  string msg = 4;
+  string msg = 3;
+  SysPoly spline = 4;
+  Plan plan = 5;
+  Cost cost = 6;
 }
 
 service MotionPlanner {
   rpc HandleStartRequest(StartPlanRequest) returns (StartPlanResponse) {}
-  rpc HandleRetrieveRequest(RetrievePlanRequest) returns (RetrievePlanResponse) {}
+  rpc HandleRetrieveRequest(RetrievePlanRequest)
+      returns (RetrievePlanResponse) {}
 }
-

--- a/proto/planning/api.proto
+++ b/proto/planning/api.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "proto/planning/types.proto";
 package proto;
 
 /** Request containing all information necessary to uniquely define a planning
@@ -7,7 +8,7 @@ package proto;
 message StartPlanRequest {
   string id = 1;
   ProblemDef def = 2;
-  string legacy_params = 4;  // TODO(@davebambrick): deprecate
+  string legacy_params = 3;  // TODO(@davebambrick): deprecate
 }
 /** Response which contains the result of attempting to start computation of a
  * solution for the corresponding StartPlanRequest. */
@@ -19,21 +20,6 @@ message StartPlanResponse {
   string msg = 3;
 }
 
-/** Enum which controls plan retrieval behavior for a given RetrievePlanRequest.
- * Retrieval behavior is as follows:
- *   - UNSPECIFIED. Default value
- *   - BLOCKING. Wait indefinitely for the computation of the plan to complete.
- *   - IF_READY. Only return if computation is completed at the time of reciept
- *     of the request. Equivalent to a timeout of length zero.
- *   - WITH_TIMEOUT. Wait for a maximum interval of timeout_ms for computation
- *     to complete before returning failure.
- */
-enum RetrieveType {
-  UNSPECIFIED = 0;
-  BLOCKING = 1;
-  IF_READY = 2;
-  WITH_TIMEOUT = 3;
-}
 /** Request to retrieve a plan with a unique ID, in the manner dictated by the
  * given retrieval type. */
 message RetrievePlanRequest {
@@ -52,7 +38,6 @@ message RetrievePlanResponse {
   string msg = 3;
   SysPoly spline = 4;
   Plan plan = 5;
-  Cost cost = 6;
 }
 
 service MotionPlanner {

--- a/proto/planning/types.proto
+++ b/proto/planning/types.proto
@@ -1,0 +1,111 @@
+syntax = "proto3";
+
+package proto;
+
+/** Joint configuration for a single robot. */
+message Conf {
+  repeated double data = 1;
+}
+
+/** "System configuration", a type mapping individual robots to respective
+ * independent configurations. To be a valid configuration, all robots must be
+ * specified. */
+message SystemConf {
+  map<string, Conf> data = 1;
+}
+
+/** A vector of coefficients for a single monomial. */
+message Coeffs {
+  repeated double data = 1;
+}
+
+/* Individual piecewise polynomial trajectory, uniquely defined by
+ *   1) an array of "breaks", or points in time representing
+ *      the intervals for constituent polynomials.
+ *   2) an array of m-by-n matrices of coeffecient vectors, where
+ *      a single constituent matrix uniquely defines a given
+ *      polynomial. each matrix contains the coefficients of the
+ *      underlying additive monomials.
+ * note: the coeffecients are stored in this message type
+ * as a vector of vectors, so care must be taken to properly
+ */
+message Poly {
+  repeated double breaks = 1;
+  uint32 rows = 2;
+  uint32 cols = 3;
+  // vector of monomial coefficients
+  repeated Coeffs coeffs = 4;
+}
+
+/** A robot state which provides the joint position q(t) and velocity q'(t) for
+ * utime t for N named joints.*/
+message State {
+  uint64 utime = 1;
+  uint32 num_joints = 2;
+  repeated string joint_name = 3;
+  repeated double joint_position = 4;
+  repeated double joint_velocity = 5;
+}
+
+/** A waypoint plan comprised of many robot states. */
+message Plan {
+  repeated State states = 1;
+}
+
+/** System polynomial; a map of individual polynomials to their respective
+ * target robots. */
+message SysPoly {
+  map<string, Poly> data = 1;
+}
+
+/** Constrains the position of a point Q, rigidly attached to a frame B, to be
+ * within a bounding box measured and expressed in frame A.
+ * Reference:
+ * https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_position_constraint.html
+ */
+message PositionConstraint {
+  string frame_A = 1;
+  string frame_B = 2;
+  repeated double p_AQ_lower = 3;
+  repeated double p_AQ_upper = 4;
+  repeated double p_BQ = 5;
+}
+/** Constrains that the angle between a vector a and another vector b is
+ * between [θ_lower, θ_upper].
+ * Reference:
+ * https://drake.mit.edu/doxygen_cxx/classdrake_1_1multibody_1_1_angle_between_vectors_constraint.html
+ */
+message AngleBetweenVectorsConstraint {
+  string frame_A = 1;
+  string frame_B = 2;
+  repeated double a_A = 3;
+  repeated double b_B = 4;
+  double angle_lower = 5;
+  double angle_upper = 6;
+}
+/** The set of all constraints for the given planning problem. */
+message Constraints {
+  repeated PositionConstraint pos_constraints = 1;
+  repeated AngleBetweenVectorsConstraint angle_constraints = 2;
+  // TODO(@davebambrick): Add collision filtering
+}
+
+/** All information which uniquely defines a given planning problem. */
+message ProblemDef {
+  string name = 1;
+  SystemConf goal = 2;
+  SystemConf start = 3;
+  Parameters params = 4;
+  Constraints constraints = 5;
+}
+
+/** Parameters which provide supplemental information to the planner (f.e., what
+ * kind of system is requesting a plan). */
+message Parameters {
+  string system_name = 1;
+  string model_directive = 2;
+  string robot_name = 3;
+  string link_name = 4;
+  repeated double link_axis = 5;
+  repeated double world_axis = 6;
+}

--- a/proto/planning/types.proto
+++ b/proto/planning/types.proto
@@ -45,6 +45,7 @@ message State {
   repeated string joint_name = 3;
   repeated float joint_position = 4;
   repeated float joint_velocity = 5;
+  repeated float joint_effort = 6;
 }
 
 /** A waypoint plan comprised of many robot states. */

--- a/proto/planning/types.proto
+++ b/proto/planning/types.proto
@@ -97,6 +97,10 @@ message ProblemDef {
   SystemConf start = 3;
   Parameters params = 4;
   Constraints constraints = 5;
+  // TODO(@davebambrick): deprecate ASAP
+  double orientation_tol = 6;
+  bool use_columnar_constraint = 7;
+  bool use_height_constraint = 8;
 }
 
 /** Parameters which provide supplemental information to the planner (f.e., what
@@ -105,7 +109,20 @@ message Parameters {
   string system_name = 1;
   string model_directive = 2;
   string robot_name = 3;
-  string link_name = 4;
-  repeated double link_axis = 5;
-  repeated double world_axis = 6;
+}
+
+/** Enum which controls plan retrieval behavior for a given RetrievePlanRequest.
+ * Retrieval behavior is as follows:
+ *   - UNSPECIFIED. Default value
+ *   - BLOCKING. Wait indefinitely for the computation of the plan to complete.
+ *   - IF_READY. Only return if computation is completed at the time of reciept
+ *     of the request. Equivalent to a timeout of length zero.
+ *   - WITH_TIMEOUT. Wait for a maximum interval of timeout_ms for computation
+ *     to complete before returning failure.
+ */
+enum RetrieveType {
+  UNSPECIFIED = 0;
+  BLOCKING = 1;
+  IF_READY = 2;
+  WITH_TIMEOUT = 3;
 }

--- a/proto/planning/types.proto
+++ b/proto/planning/types.proto
@@ -43,8 +43,8 @@ message State {
   uint64 utime = 1;
   uint32 num_joints = 2;
   repeated string joint_name = 3;
-  repeated double joint_position = 4;
-  repeated double joint_velocity = 5;
+  repeated float joint_position = 4;
+  repeated float joint_velocity = 5;
 }
 
 /** A waypoint plan comprised of many robot states. */


### PR DESCRIPTION
### Background

We want to send the piecewise-linear plan alongside the piecewise-polynomial spline (see https://github.com/DexaiRobotics/planning_service/pull/65).

### What's new

- [x] Message types `State` and `Plan` which encode full-system joint information (position, velocity).
- [x] Consolidate constraints and parameters into `ProblemDef`

### Related work

- [x] https://github.com/DexaiRobotics/planning_service/pull/65 needs this PR

### TODOs / Nice-To-Haves

- [ ] [Add system tests for new feature.]