### PR TITLE
build inside protodefs repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+protobuf

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,6 @@
+version: v1
+plugins:
+  - name: go
+    out: .
+  - name: go-grpc
+    out: .

--- a/proto/planning/builder.proto
+++ b/proto/planning/builder.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+import "proto/planning/types.proto";
+package proto;
+option go_package = "protobuf/planning";
+
+
+/** Request containing all information necessary to start generating a set of
+ * IRIS regions for a given planning context from a set of seed configurations.
+ */
+message StartBuildFromConfsRequest {
+  string request_id = 1;
+  // Unique ID for a given plan context
+  PlanContextId context_id = 2;
+  // set of configurations; we will use these to construct planning problems
+  // synthetically
+  repeated SystemConf seed_configs = 3;
+}
+
+/** Request containing all information necessary to start generating a set of
+ * IRIS regions for a given planning context from a set of edges which satisfy
+ * the given context. */
+message StartBuildFromEdgesRequest {
+  string request_id = 1;
+  // Unique ID for a given plan context
+  PlanContextId context_id = 2;
+  // set of configurations; we will use these to construct planning problems
+  // synthetically
+  repeated SystemConfEdge seed_edges = 3;
+}
+
+/** Response which contains the result of attempting to start computation of a
+ * solution for the corresponding StartBuildFromConfsRequest. */
+message StartBuildResponse {
+  string request_id = 1;
+  bool success = 2;
+  // msg used to convey extra information to client; usually
+  // for explaining cause of error
+  string msg = 3;
+}
+
+/** Request to retrieve the status of a given IRIS region generation job with a
+ * unique ID. */
+message ReportBuildStatusRequest {
+  string request_id = 1;
+}
+
+/** Response which contains the result of retrieving the status of the job with
+ * the given ID. */
+message ReportBuildStatusResponse {
+  string request_id = 1;
+  bool complete = 2;
+  string msg = 3;
+}
+
+service IrisBuilder {
+  /** Start a build job from a set of seed confiugrations. */
+  rpc HandleStartBuildFromConfsRequest(StartBuildFromConfsRequest)
+      returns (StartBuildResponse) {}
+  /** Start a build job from a set of seed confiugration edges. */
+  rpc HandleStartBuildFromEdgesRequest(StartBuildFromEdgesRequest)
+      returns (StartBuildResponse) {}
+  /** Return a reoprt on the status of a build job with the given original
+   * request ID. */
+  rpc HandleReportStatusRequest(ReportBuildStatusRequest)
+      returns (ReportBuildStatusRequest) {}
+}

--- a/proto/planning/generate_id.proto
+++ b/proto/planning/generate_id.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "proto/planning/types.proto";
 package proto;
+option go_package = "protobuf/planning";
 
 /** Request containing the information corresponding to a unique planning
  * context; concretely, a geometric configuration, and a set of optional

--- a/proto/planning/planner.proto
+++ b/proto/planning/planner.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "proto/planning/types.proto";
 package proto;
+option go_package = "protobuf/planning";
 
 /** Request containing all information necessary to uniquely define a planning
  * problem in a format accepted by the planner. */

--- a/proto/planning/types.proto
+++ b/proto/planning/types.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package proto;
+option go_package = "protobuf/planning";
 
 /** Joint configuration for a single robot. */
 message Conf {
@@ -14,6 +15,12 @@ message SystemConf {
   map<string, Conf> data = 1;
 }
 
+/** Pair of system configurations representing an edge in the configuration
+ * space. */
+message SystemConfEdge {
+  SystemConf v1 = 1;
+  SystemConf v2 = 2;
+}
 /** A vector of coefficients for a single monomial. */
 message Coeffs {
   repeated double data = 1;


### PR DESCRIPTION
### Background

These changes allow go protobuf bindings to be built using `buf generate --template buf.gen.yaml`

There are probably a number of dependencies you need to use this though

### What's new

- [ ] [New feature description]

### Related work

- [ ] [link] needs this PR

### TODOs / Nice-To-Haves

- [ ] [Add system tests for new feature.]
