### PR TITLE
add PlanContextId to plan request

### DIFF
--- a/proto/planning/types.proto
+++ b/proto/planning/types.proto
@@ -85,6 +85,8 @@ message ProblemDef {
   double orientation_tol = 6;
   bool use_columnar_constraint = 7;
   bool use_height_constraint = 8;
+
+  PlanContextId context_id = 9;
 }
 
 /** Parameters which provide supplemental information to the planner (f.e., what

--- a/proto/planning/types.proto
+++ b/proto/planning/types.proto
@@ -85,7 +85,6 @@ message ProblemDef {
   double orientation_tol = 6;
   bool use_columnar_constraint = 7;
   bool use_height_constraint = 8;
-
   PlanContextId context_id = 9;
 }
 


### PR DESCRIPTION
### Background

We want to transition to a paradigm of using only the unique PlanContext identifier to query for a specific motion plan.


### What's new

- [x] Add field `PlanContextId context_id` to `ProblemDef` message.

### Related work

- [ ] [link] needs this PR

### TODOs / Nice-To-Haves

- [ ] [Add system tests for new feature.]
