### PR TITLE
Add visualizer support for IRIS regions

### DIFF
--- a/examples/planning/python/visualizer.py
+++ b/examples/planning/python/visualizer.py
@@ -54,19 +54,25 @@ def cli():
 def start(id, dmd, force, iris) -> None:
     if id is not None:
         req = StartVisualizerRequest(
-            context_id=PlanContextId(value=id), enable_sliders=True, force_reload=force, show_iris_regions=iris
+            context_id=PlanContextId(value=id),
+            enable_sliders=True,
+            force_reload=force,
+            show_iris_regions=iris,
         )
     elif dmd is not None:
-         req = StartVisualizerRequest(
-            dmd_filename=dmd, enable_sliders=True, force_reload=force, show_iris_regions=False
+        req = StartVisualizerRequest(
+            dmd_filename=dmd,
+            enable_sliders=True,
+            force_reload=force,
+            show_iris_regions=False,
         )
     else:
         raise ValueError("A reference to a model was not added to the request!")
-    
+
     with grpc.insecure_channel("0.0.0.0:5550") as channel:
         stub = VisualizerStub(channel)
         resp = stub.StartVisualizer(req)
-    print(resp)
+
 
 @cli.command("stop", help="Stop the visualizer.")
 def stop() -> None:

--- a/examples/planning/python/visualizer.py
+++ b/examples/planning/python/visualizer.py
@@ -39,21 +39,26 @@ def cli():
     help="Name of the DMD file which you would like to visualize.",
 )
 @click.option(
+    "--iris",
+    is_flag=True,
+    default=False,
+    help="Show IRIS regions for the given context.",
+)
+@click.option(
     "-f",
     "--force",
     is_flag=True,
     default=False,
     help="Force reload of the visualizer with a new model.",
 )
-def start(id, dmd, force) -> None:
-    print(id, dmd, force)
+def start(id, dmd, force, iris) -> None:
     if id is not None:
         req = StartVisualizerRequest(
-            context_id=PlanContextId(value=id), enable_sliders=True, force_reload=force
+            context_id=PlanContextId(value=id), enable_sliders=True, force_reload=force, show_iris_regions=iris
         )
     elif dmd is not None:
          req = StartVisualizerRequest(
-            dmd_filename=dmd, enable_sliders=True, force_reload=force
+            dmd_filename=dmd, enable_sliders=True, force_reload=force, show_iris_regions=False
         )
     else:
         raise ValueError("A reference to a model was not added to the request!")

--- a/proto/planning/visualizer.proto
+++ b/proto/planning/visualizer.proto
@@ -37,6 +37,7 @@ message StartVisualizerRequest {
   // When true, add sliders to control each joint position.
   bool enable_sliders = 4;
   bool force_reload = 5;
+  bool show_iris_regions = 6;
 }
 
 service Visualizer {


### PR DESCRIPTION
### Background

We want the visualizer to be able to display IRIS regions in order to support generation tasks.

### What's new

- [x] Add flag `show_iris_regions` to `StartVisualizerRequest`.
- [x] Update Python client to accept `--iris` as option to set `show_iris_regions: True`.

### Related work

- [x]  https://github.com/SonyResearch/planning_service/pull/24 needs this PR

### TODOs / Nice-To-Haves

- [ ] [Add system tests for new feature.]
