### PR TITLE
Support plans between start and goal poses

### DIFF
--- a/proto/planning/basic_types.proto
+++ b/proto/planning/basic_types.proto
@@ -56,7 +56,9 @@ message RigidTransform {
 
 message State {
   oneof data {
+    // System configuration.
     SystemConf system_conf = 1;
+    // Rigid transformation between two frames.
     RigidTransform rigid_transform = 2;
   }
 }
@@ -146,6 +148,8 @@ message ProblemDef {
   State start = 3;
   PlanContextId context_id = 4;
   Parameters params = 5;
+  // Initial guess for IK solver.
+  SystemConf ik_seed = 6;
 }
 
 // Parameters which provide supplemental information to the planner (f.e., what

--- a/proto/planning/basic_types.proto
+++ b/proto/planning/basic_types.proto
@@ -20,13 +20,45 @@ message SystemConf {
   map<string, Conf> data = 1;
 }
 
-// Pair of system configurations representing an edge in the configuration
-// space.
+// Ordered pair of system configurations.
 message SystemConfEdge {
   // Vertex 1
   SystemConf u = 1;
   // Vertex 2
   SystemConf v = 2;
+}
+
+// Quaternion.
+message Quaternion {
+  double w = 1;
+  double x = 2;
+  double y = 3;
+  double z = 4;
+}
+
+// A message representing a rigid transformation of a frame A relative to a
+// frame B.
+message RigidTransform {
+  // The target frame A.
+  string frame_A = 1;
+  // The relative frame B.
+  string frame_B = 2;
+  // A 3-vector representing the translation of the origin of frame A relative
+  // to the origin of frame B.
+  repeated double translation = 3;
+  // The rotation of the origin of frame A relative to the origin of frame B.
+  oneof rotation {
+    // Quaternion representation.
+    Quaternion quat = 4;
+    // TODO(@davebambrick): Add RPY, rotation matrix
+  }
+}
+
+message State {
+  oneof data {
+    SystemConf system_conf = 1;
+    RigidTransform rigid_transform = 2;
+  }
 }
 
 // Real-valued coefficients of a single polynomial.
@@ -101,24 +133,18 @@ message ConstraintsSet {
   repeated PositionConstraint pos_constraints = 1;
   // The set of all angle constraints.
   repeated AngleBetweenVectorsConstraint angle_constraints = 2;
-  // TODO(@davebambrick): Add collision filtering
 }
 
 // The set of all information which uniquely defines a planning problem.
 message ProblemDef {
   // Plan name.
   string name = 1;
-  // Goal configuration.
-  SystemConf goal = 2;
-  // Start configuration.
-  SystemConf start = 3;
-  Parameters params = 4;
-  ConstraintsSet constraints = 5;
-  // TODO(@davebambrick): deprecate ASAP
-  double orientation_tol = 6;
-  bool use_columnar_constraint = 7;
-  bool use_height_constraint = 8;
-  PlanContextId context_id = 9;
+  // Goal state.
+  State goal = 2;
+  // Start state.
+  State start = 3;
+  PlanContextId context_id = 4;
+  Parameters params = 5;
 }
 
 // Parameters which provide supplemental information to the planner (f.e., what

--- a/proto/planning/planner.proto
+++ b/proto/planning/planner.proto
@@ -8,7 +8,6 @@ package proto;
 message StartPlanRequest {
   string id = 1;
   ProblemDef problem_def = 2;
-  string legacy_params = 3;  // TODO(@davebambrick): deprecate
 }
 // Response which contains the result of attempting to start computation of a
 // solution for the corresponding StartPlanRequest.


### PR DESCRIPTION
### Background

We want to support IK-based Cartesian-linear motion.

### What's new

- [x] Update `ProblemDef` to support IK:
  - [x] Store the `start` and `goal` as a `State` instead of a `SystemConf`, which can hold either joint (`SystemConf`) or pose (`RigidTransform`) data.
  - [x] Add field `SystemConf ik_seed` to provide the IK solver with an initial guess.
- [x] Add `RigidTransform` and `Quaternion`.

### Related work

- [ ] https://github.com/SonyResearch/planning_service/pull/59 needs this PR

### TODOs / Nice-To-Haves

- [ ] [Add system tests for new feature.]
