### PR TITLE
remove redundant success, msg fields

### DIFF
--- a/proto/planning/builder.proto
+++ b/proto/planning/builder.proto
@@ -40,11 +40,8 @@ message StartBuildRequest {
 // Response which contains the result of attempting to start computation of a
 // solution for the corresponding StartBuildRequest.
 message StartBuildResponse {
+  // ID of request. Used to track job status.
   string id = 1;
-  bool success = 2;
-  // msg used to convey extra information to client; usually
-  // for explaining cause of error
-  string msg = 3;
 }
 
 // Request to retrieve the status of a given IRIS region generation job with a

--- a/proto/planning/generate_id.proto
+++ b/proto/planning/generate_id.proto
@@ -12,12 +12,8 @@ message RegisterPlanContextRequest {
 // Response which contains the resultant unique ID for the provided planning
 // context.
 message RegisterPlanContextResponse {
-  bool success = 1;
   // unique hash-based identifier
-  PlanContextId context_id = 2;
-  // msg used to convey extra information to client; usually
-  // for explaining cause of error
-  string msg = 3;
+  PlanContextId context_id = 1;
 }
 
 // Given a unique planning context, return the corresponding hash value which

--- a/proto/planning/planner.proto
+++ b/proto/planning/planner.proto
@@ -13,10 +13,6 @@ message StartPlanRequest {
 // solution for the corresponding StartPlanRequest.
 message StartPlanResponse {
   string id = 1;
-  bool success = 2;
-  // msg used to convey extra information to client; usually
-  // for explaining cause of error
-  string msg = 3;
 }
 
 // Request to retrieve a plan with a unique ID, in the manner dictated by the
@@ -38,15 +34,11 @@ message RetrievePlanRequest {
 // Response which contains the result of retrieving the plan with the given ID.
 message RetrievePlanResponse {
   string id = 1;
-  bool success = 2;
-  // msg used to convey extra information to client; usually
-  // for explaining cause of error
-  string msg = 3;
   oneof plan_data {
     // The returned plan as a spline, given as a polynomial function of time.
-    SystemPolynomial spline = 4;
+    SystemPolynomial spline = 2;
     // The returned plan as a waypoint trajectory.
-    SystemTrajectory traj = 5;
+    SystemTrajectory traj = 3;
   }
 }
 


### PR DESCRIPTION
### Background

We erroneously included `success` and `msg` fields to most request messages, in order to convey the success of the operation and detail about potential failures. This is already covered, however, by the `grpc::Status` object, which captures both of these properties.

### What's new

- [ ] Remove `success`, `msg` fields.

### Related work

- [ ] [link] needs this PR

### TODOs / Nice-To-Haves

- [ ] [Add system tests for new feature.]
