### PR TITLE
Add field solution type to planning problem

### DIFF
--- a/proto/planning/basic_types.proto
+++ b/proto/planning/basic_types.proto
@@ -54,6 +54,8 @@ message RigidTransform {
   }
 }
 
+// A representation of the robot's state using either joint positions or pose
+// data.
 message State {
   oneof data {
     // System configuration.
@@ -102,7 +104,9 @@ message SystemPolynomial {
 
 // System trajectory. An array of system configurations in time.
 message SystemTrajectory {
+  // Array of system configurations.
   repeated SystemConf data = 1;
+  // Sampling interval in milliseconds between each waypoint.
   uint32 interval_ms = 2;
 }
 
@@ -138,6 +142,15 @@ message ConstraintsSet {
   repeated AngleBetweenVectorsConstraint angle_constraints = 2;
 }
 
+// Enum which specifies the desired type of returned solution.
+enum SolutionType {
+  // Default value.
+  UNSPECIFIED_SOLUTION_TYPE = 0;
+  // Return a trajectory which requires the minimum amount of time to complete.
+  TIME_OPTIMAL = 1;
+  // Return a trajectory which is linear in Cartesian space.
+  LINEAR = 2;
+}
 // The set of all information which uniquely defines a planning problem.
 message ProblemDef {
   // Plan name.
@@ -150,6 +163,7 @@ message ProblemDef {
   Parameters params = 5;
   // Initial guess for IK solver.
   SystemConf ik_seed = 6;
+  SolutionType solution_type = 7;
 }
 
 // Parameters which provide supplemental information to the planner (f.e., what


### PR DESCRIPTION
### Background

We want to be able to specify what type of solution should be returned from the planner.

### What's new

- [ ] [New feature description]

### Related work

- [ ] [link] needs this PR

### TODOs / Nice-To-Haves

- [ ] [Add system tests for new feature.]
