### PR TITLE
Add CalcRelativePose to public API

### DIFF
--- a/proto/planning/planner.proto
+++ b/proto/planning/planner.proto
@@ -42,8 +42,32 @@ message RetrievePlanResponse {
   }
 }
 
+// Request to calculate the pose of a given joint configuration.
+message CalcRelativePoseRequest {
+  // ID of the target context.
+  PlanContextId context_id = 1;
+  // The joint configuration as a system conf.
+  SystemConf system_conf = 2;
+  // The relative frame.
+  string frame_A = 3;
+  // The target frame.
+  string frame_B = 4;
+}
+
+// Response containing calculated pose.
+message CalcRelativePoseResponse {
+  // Pose X_AB.
+  RigidTransform pose = 1;
+}
+
 service MotionPlanner {
+  // Given a request for a motion plan, initiate a job to compute its solution.
   rpc HandleStartRequest(StartPlanRequest) returns (StartPlanResponse) {}
+  // Given a request to retrieve a computed motion plan, retrieve the computed
+  // solution.
   rpc HandleRetrieveRequest(RetrievePlanRequest)
       returns (RetrievePlanResponse) {}
+  // Calculate a relative pose.
+  rpc CalcRelativePose(CalcRelativePoseRequest)
+      returns (CalcRelativePoseResponse) {}
 }


### PR DESCRIPTION
### Background

We want to be able to query for a pose of a given frame for some joint position.

### What's new

- [x] Add `CalcRelativePose` RPC to `MotionPlanner`.

### Related work

- [ ] https://github.com/SonyResearch/planning_service/pull/108 needs this PR

### TODOs / Nice-To-Haves

- [ ] [Add system tests for new feature.]
